### PR TITLE
Move symfony dependencies to "suggest"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,14 +2,16 @@
     "name": "ua-parser/uap-php",
     "description": "A multi-language port of Browserscope's user agent parser.",
     "require": {
-        "symfony/yaml": "^2.0 || ^3.0 || ^4.0",
-        "symfony/filesystem": "^2.0 || ^3.0 || ^4.0",
-        "symfony/finder": "^2.0 || ^3.0 || ^4.0",
-        "symfony/console": "^2.0 || ^3.0 || ^4.0",
         "php": ">=5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0 || ^5.0"
+    },
+    "suggest": {
+        "symfony/yaml": "Required for CLI usage",
+        "symfony/filesystem": "Required for CLI usage",
+        "symfony/finder": "Required for CLI usage",
+        "symfony/console": "Required for CLI usage",   
     },
     "prefer-stable": true,
     "license": "MIT",


### PR DESCRIPTION
The symfony dependencies are only requires for CLI usage.
Move them to "suggest" so the library can be used without depending upon them.

Per https://github.com/ua-parser/uap-php/issues/43